### PR TITLE
Add support for diffs created with --no-prefix option

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,10 @@
          * 解析 gitdiff 消息
          *
          * @param {string} source gitdiff消息内容
+         * @param {string} noPrefix flag indicating if diff was generated with --no-prefix
          * @return {Object}
          */
-        parse: function (source) {
+        parse: function (source, noPrefix) {
             var infos = [];
             var stat = STAT_START;
             var currentInfo;
@@ -102,16 +103,16 @@
                                 var oldPath = simiLine.slice(spaceIndex + 1);
                                 var newPath = lines[++i].slice(4); // next line must be "+++ xxx"
                                 if (oldPath === '/dev/null') {
-                                    newPath = newPath.slice(2);
+                                    newPath = newPath.slice(!noPrefix ? 2 : 0);
                                     currentInfoType = 'add';
                                 }
                                 else if (newPath === '/dev/null') {
-                                    oldPath = oldPath.slice(2);
+                                    oldPath = oldPath.slice(!noPrefix ? 2 : 0);
                                     currentInfoType = 'delete';
                                 } else {
                                     currentInfoType = 'modify';
-                                    oldPath = oldPath.slice(2);
-                                    newPath = newPath.slice(2);
+                                    oldPath = oldPath.slice(!noPrefix ? 2 : 0);
+                                    newPath = newPath.slice(!noPrefix ? 2 : 0);
                                 }
 
                                 currentInfo.oldPath = oldPath;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdiff-parser",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "gitdiff-parser",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "main": "index.js",
   "scripts": {
     "test": "jest"
   },
   "devDependencies": {
-    "parse-diff": "0.4.0",
-    "jest": "^24.1.0"
+    "jest": "^24.1.0",
+    "parse-diff": "0.4.0"
   },
   "files": [
     "index.js",

--- a/test/git-no-prefix.test.js
+++ b/test/git-no-prefix.test.js
@@ -1,0 +1,55 @@
+const path = require('path');
+const fs = require('fs');
+const parser = require('../index');
+
+describe("git specific tests with no-prefix", () => {
+
+    const parse = (filename) => {
+        return parser.parse( fs.readFileSync(path.resolve(__dirname, "git", filename), 'utf-8'), true );
+    };
+
+    it("should have type add", () => {
+        const diff = parse("add-no-prefix.diff");
+        const file = diff[0];
+        expect(file.type).toBe("add");
+        expect(file.oldPath).toBe("/dev/null");
+        expect(file.newPath).toBe("myApp/a.txt");
+        expect(file.newMode).toBe('100644');
+    });
+
+    it("should have type delete", () => {
+        const diff = parse("rm-no-prefix.diff");
+        const file = diff[0];
+        expect(file.type).toBe("delete");
+        expect(file.oldPath).toBe("myApp/a.txt");
+        expect(file.oldMode).toBe('100644');
+        expect(file.newPath).toBe("/dev/null");
+    });
+
+    it("should have type rename", () => {
+        const diff = parse("mv-no-prefix.diff");
+        const file = diff[0];
+        expect(file.type).toBe("rename");
+        expect(file.oldPath).toBe("myApp/b.txt");
+        expect(file.newPath).toBe("myApp/c.txt");
+    });
+
+    it("should have type modify", () => {
+        const diff = parse("edit-no-prefix.diff");
+        const file = diff[0];
+        expect(file.type).toBe("modify");
+        expect(file.oldPath).toBe("myApp/a.txt");
+        expect(file.newPath).toBe("myApp/a.txt");
+        expect(file.oldMode).toBe('100644');
+        expect(file.newMode).toBe('100644');
+    });
+
+    it("should parse filename correctly if whitespace included", () => {
+        const diff = parse("edit-ws-no-prefix.diff");
+        const file = diff[0];
+        expect(file.type).toBe("modify");
+        expect(file.oldPath).toBe("myApp/a b/a.txt");
+        expect(file.newPath).toBe("myApp/a b/a.txt");
+    });
+
+});

--- a/test/git/add-no-prefix.diff
+++ b/test/git/add-no-prefix.diff
@@ -1,0 +1,7 @@
+diff --git myApp/a.txt myApp/a.txt
+new file mode 100644
+index 0000000..7898192
+--- /dev/null
++++ myApp/a.txt
+@@ -0,0 +1 @@
++a

--- a/test/git/edit-no-prefix.diff
+++ b/test/git/edit-no-prefix.diff
@@ -1,0 +1,7 @@
+diff --git myApp/a.txt myApp/a.txt
+index 7898192..7e8a165 100644
+--- myApp/a.txt
++++ myApp/a.txt
+@@ -1 +1,2 @@
+ a
++a

--- a/test/git/edit-ws-no-prefix.diff
+++ b/test/git/edit-ws-no-prefix.diff
@@ -1,0 +1,7 @@
+diff --git myApp/a b/a.txt myApp/a b/a.txt
+index 7898192..7e8a165 100644
+--- myApp/a b/a.txt
++++ myApp/a b/a.txt
+@@ -1 +1,2 @@
+ a
++a

--- a/test/git/mv-no-prefix.diff
+++ b/test/git/mv-no-prefix.diff
@@ -1,0 +1,4 @@
+diff --git myApp/b.txt myApp/c.txt
+similarity index 100%
+rename from myApp/b.txt
+rename to myApp/c.txt

--- a/test/git/rm-no-prefix.diff
+++ b/test/git/rm-no-prefix.diff
@@ -1,0 +1,7 @@
+diff --git myApp/a.txt myApp/a.txt
+deleted file mode 100644
+index 7898192..0000000
+--- myApp/a.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-a


### PR DESCRIPTION
Hi,
I was always wondering, why the first two characters of `RnDiffApp` are cut when clicking on "view source" link. I have found out that GitHub provides diffs without git diff prefixes (a/, b/) and this library simply cuts the first two characters.

I took the fast way and added `noPrefix` flag to the `parse` method.

We could also do it smarter way and detect the prefixes, but I do not think it is worth the effort as user of this library most probably knows how diff has been generated.

Cheers,
Dominik