### PR TITLE
Fix types

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ gitDiffParser.parse(gitDiffText);
 ### API
 
 ```ts
-export type ChangeType = 'insert' | 'delete' | 'normal';
-
 export interface InsertChange {
     type: 'insert';
     content: string;
@@ -46,6 +44,8 @@ export interface NormalChange {
 }
 
 export type Change = InsertChange | DeleteChange | NormalChange;
+
+export type ChangeType = Change['type'];
 
 export interface Hunk {
     content: string;

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ export interface File {
     type: 'add' | 'delete' | 'modify' ｜ 'rename';
 }
 
-export default {
-    parse(source: string): File[];
-};
+export function parse(source: string): File[];
+
+export as namespace gitDiffParser;
 ```

--- a/README.md
+++ b/README.md
@@ -21,16 +21,31 @@ gitDiffParser.parse(gitDiffText);
 ### API
 
 ```ts
-export interface Change {
+export type ChangeType = 'insert' | 'delete' | 'normal';
+
+export interface InsertChange {
+    type: 'insert';
     content: string;
-    type: 'insert' | 'delete' | 'normal';
-    isInsert?: boolean;
-    isDelete?: boolean;
-    isNormal?: boolean;
-    lineNumber?: number;
-    oldLineNumber?: number;
-    newLineNumber?: number;
+    lineNumber: number;
+    isInsert: true;
 }
+
+export interface DeleteChange {
+    type: 'delete';
+    content: string;
+    lineNumber: number;
+    isDelete: true;
+}
+
+export interface NormalChange {
+    type: 'normal';
+    content: string;
+    isNormal: true;
+    oldLineNumber: number;
+    newLineNumber: number;
+}
+
+export type Change = InsertChange | DeleteChange | NormalChange;
 
 export interface Hunk {
     content: string;
@@ -40,6 +55,8 @@ export interface Hunk {
     newLines: number;
     changes: Change[];
 }
+
+export type FileType = 'add' | 'delete' | 'modify' | 'rename' | 'copy';
 
 export interface File {
     hunks: Hunk[];
@@ -53,7 +70,7 @@ export interface File {
     oldPath: string;
     newPath: string;
     isBinary?: boolean;
-    type: 'add' | 'delete' | 'modify' ｜ 'rename';
+    type: FileType;
 }
 
 export function parse(source: string): File[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-export type ChangeType = 'insert' | 'delete' | 'normal';
-
 export interface InsertChange {
     type: 'insert';
     content: string;
@@ -23,6 +21,8 @@ export interface NormalChange {
 }
 
 export type Change = InsertChange | DeleteChange | NormalChange;
+
+export type ChangeType = Change['type'];
 
 export interface Hunk {
     content: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,6 +50,6 @@ export interface File {
     type: FileType;
 }
 
-export default {
-    parse(source: string): File[];
-};
+export function parse(source: string): File[];
+
+export as namespace gitDiffParser;


### PR DESCRIPTION
The type export is malformed and gives errors in current versions of typescript

![image](https://user-images.githubusercontent.com/13413409/175162172-10782e4e-a782-4910-8615-4016645d29ab.png)

```
node_modules/gitdiff-parser/index.d.ts(36,16): error TS2714: The expression of an export assignment must be an identifier or qualified name in an ambient context.
node_modules/gitdiff-parser/index.d.ts(37,34): error TS1005: '{' expected.
```

This also does not work if you want to use `gitDiffParser` globally (not importing). Since the `index.js` exports as a UMD, I followed the example https://devblogs.microsoft.com/typescript/writing-dts-files-for-types/

With this type, all the following works

```ts
// Reference for `<script>`-imported library
/// <reference path="gitdiff-parser" />

gitDiffParser.parse(gitContent);
```

```ts
import { parse } from "gitdiff-parser";

parse(gitContent);
```

```ts
import gitDiffParser from "gitdiff-parser";

gitDiffParser.parse(gitContent);
```

As a bonus I added exports for `FileType` and `ChangeType`.